### PR TITLE
docs: Document CI environment requirements in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -468,3 +468,13 @@ The highest compliment we can receive: "It just works."
 - **Document configs**: Keep all config files in sync or clearly document differences
 
 **Lesson learned**: When fixing mypy CI failures for Dataset Auto-Fetch, we updated `pyproject.toml` but CI was using `mypy.ini`. Always check for multiple config files.
+
+### 18. Development Environment Setup (MANDATORY)
+**Rule**: Match CI environment to prevent version-specific issues
+- **Python Version**: Python 3.11.x (CI uses 3.11.13)
+- **Ruff Version**: ruff==0.12.5
+- **Mypy Version**: mypy==1.17.0
+- **Why this matters**: Different Python/tool versions catch different issues
+- **Version mismatch example**: Python 3.9 allows `typing.List`, but Python 3.11 + ruff 0.12.5 flags it as deprecated (UP035)
+- **Verification**: Run `python --version` and `ruff --version` to confirm correct versions
+- **Lint locally**: Always run `ruff check src/swebench_runner tests` before pushing to catch issues early

--- a/activate.sh
+++ b/activate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Activate the Python 3.11 virtual environment for this project
+
+if [ ! -d ".venv" ]; then
+    echo "Creating virtual environment with Python 3.11..."
+    /opt/homebrew/bin/python3.11 -m venv .venv
+fi
+
+source .venv/bin/activate
+
+# Verify correct Python version
+python_version=$(python --version 2>&1)
+if [[ ! "$python_version" == *"3.11"* ]]; then
+    echo "Warning: Expected Python 3.11, but got $python_version"
+fi
+
+echo "Activated Python environment: $python_version"
+echo "Run 'deactivate' to exit the virtual environment"


### PR DESCRIPTION
## Summary
Adds critical development environment setup requirements to CLAUDE.md based on lessons learned from PR #11's CI failures.

## Context
While investigating PR #11, we discovered that lint was failing in CI but passing locally due to environment differences:
- CI uses Python 3.11.13 with ruff 0.12.5
- Local development was on Python 3.9.6
- Different ruff versions catch different issues (e.g., `typing.List` deprecation)

## Changes
1. **Added Section 18 to CLAUDE.md**: Documents mandatory CI environment matching
   - Python 3.11.x (CI uses 3.11.13)
   - ruff==0.12.5
   - mypy==1.17.0
   
2. **Created activate.sh**: Helper script to activate Python 3.11 virtual environment
   - Auto-creates .venv with correct Python version
   - Verifies Python version on activation
   - Provides clear feedback to developers

## Benefits
- Prevents CI failures due to version mismatches
- Saves debugging time when PRs fail CI but pass locally
- Provides clear, actionable requirements (not installation instructions)
- Real-world example included to show why this matters

## Test plan
- [x] Verified Python 3.11.13 installation
- [x] Confirmed ruff 0.12.5 catches the same issues as CI
- [x] activate.sh script tested and working
- [x] .venv properly ignored in .gitignore

This documentation will help all contributors avoid the frustrating experience of "works on my machine" CI failures.